### PR TITLE
Update action to use node16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: '12'
+          node-version: '16'
 
       - run: yarn install
 

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
     default: 'false'
     required: false
 runs:
-  using: node12
+  using: node16
   main: dist/index.js
 branding:
   icon: bookmark


### PR DESCRIPTION
Updates the action to use Node 16.
See https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/